### PR TITLE
Fixed corruption of Emacs window buffer history

### DIFF
--- a/idle-highlight-in-visible-buffers-mode.el
+++ b/idle-highlight-in-visible-buffers-mode.el
@@ -70,7 +70,7 @@
   "Remove highlighting from all visible buffers."
   (save-window-excursion
     (dolist (buffer (idle-highlight-in-visible-buffers-buffers-list))
-      (switch-to-buffer buffer)
+      (set-buffer buffer)
       (when idle-highlight-in-visible-buffers-regexp
         (unhighlight-regexp idle-highlight-in-visible-buffers-regexp)))
     (setq idle-highlight-in-visible-buffers-regexp nil)))
@@ -84,7 +84,7 @@
       (idle-highlight-in-visible-buffers-unhighlight-word)
       (save-window-excursion
         (dolist (buffer (idle-highlight-in-visible-buffers-buffers-list))
-          (switch-to-buffer buffer)
+          (set-buffer buffer)
           (setq idle-highlight-in-visible-buffers-regexp (concat "\\<" (regexp-quote target) "\\>"))
           (highlight-regexp idle-highlight-in-visible-buffers-regexp 'idle-highlight-in-visible-buffers))))))
 


### PR DESCRIPTION
The use of function switch-to-buffer was causing unexpected changes of the buffer history list which is assigned to every Emacs window.

As a side effect, the code dependent on the window buffer history was influenced by this defect negative way. (E.g. sliding of buffer in the Emacs frame stopped working well, because used function 'switch-to-prev-buffer' in such code is using buffer history to ensure sliding of the buffer across windows in the Emacs frame.)

See also the WANING message in the help text of function 'switch-to-buffer':

WARNING: This is NOT the way to work on another buffer temporarily within a Lisp program!  Use ‘set-buffer’ instead.  That avoids messing with the ‘window-buffer’ correspondences.

The patch should fix all issues caused by this corruption of Emacs window buffer history.